### PR TITLE
fix: 동시성 테스트 시 중복 Insert 이슈 수정 #6

### DIFF
--- a/src/main/java/com/numble/tracking/domain/UrlCounter.java
+++ b/src/main/java/com/numble/tracking/domain/UrlCounter.java
@@ -6,12 +6,17 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "url_counter",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"url", "date"}))
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -20,7 +25,7 @@ public class UrlCounter {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 200)
     private String url;
 
     @Column(nullable = false)
@@ -29,20 +34,21 @@ public class UrlCounter {
     @Column(nullable = false)
     private int count;
 
-    /*@Version
-    private Long version;*/
+    @Version
+    private int version;
 
-    public UrlCounter(String url, LocalDate date) {
-        this.url = url;
-        this.date = date;
-    }
-
-    /*public UrlCounter(long id, String url, LocalDate date, int count) {
+    public UrlCounter(long id, String url, LocalDate date, int count) {
         this.id = id;
         this.url = url;
         this.date = date;
         this.count = count;
-    }*/
+    }
+
+    public UrlCounter(String url, LocalDate date) {
+        this.url = url;
+        this.date = date;
+        this.count += 1;
+    }
 
     public void increase(int count){
         this.count += count;

--- a/src/main/java/com/numble/tracking/facade/OptimisticLockStockFacade.java
+++ b/src/main/java/com/numble/tracking/facade/OptimisticLockStockFacade.java
@@ -1,0 +1,27 @@
+package com.numble.tracking.facade;
+
+import com.numble.tracking.dto.UrlCounterResponse;
+import com.numble.tracking.service.UrlCounterService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OptimisticLockStockFacade {
+
+    private UrlCounterService urlCounterService;
+
+    public OptimisticLockStockFacade(UrlCounterService urlCounterService) {
+        this.urlCounterService = urlCounterService;
+    }
+
+    public UrlCounterResponse increaseCounter(String url) throws InterruptedException {
+        while (true) {
+            try {
+                UrlCounterResponse urlCounterResponse = urlCounterService.increaseCounter(url);
+
+                return urlCounterResponse;
+            } catch (Exception e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+}

--- a/src/main/java/com/numble/tracking/repository/UrlCounterRepository.java
+++ b/src/main/java/com/numble/tracking/repository/UrlCounterRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,8 +15,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UrlCounterRepository extends JpaRepository<UrlCounter, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //@Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC)
     Optional<UrlCounter> findByUrlAndDate(String url, LocalDate date);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "update UrlCounter u set u.count = u.count + 1 where u.id = :urlCountId")
+    void increaseUrlCount(Long urlCountId);
 
     @Query("SELECT u.count FROM UrlCounter u WHERE u.url = :url AND u.date = :date")
     Long findUrlCounter(@Param("url") String url, @Param("date") LocalDate date);

--- a/src/main/java/com/numble/tracking/service/serviceImpl/UrlCounterServiceImpl.java
+++ b/src/main/java/com/numble/tracking/service/serviceImpl/UrlCounterServiceImpl.java
@@ -1,26 +1,24 @@
 package com.numble.tracking.service.serviceImpl;
 
-import com.numble.tracking.common.Constants.ExceptionClass;
-import com.numble.tracking.common.exception.CustomException;
 import com.numble.tracking.domain.UrlCounter;
 import com.numble.tracking.dto.CountStatsResponse;
 import com.numble.tracking.dto.UrlCounterResponse;
 import com.numble.tracking.repository.UrlCounterRepository;
 import com.numble.tracking.service.UrlCounterService;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UrlCounterServiceImpl implements UrlCounterService {
 
     public static final int COUNT = 1;
@@ -31,7 +29,7 @@ public class UrlCounterServiceImpl implements UrlCounterService {
     private final UrlCounterRepository urlCounterRepository;
 
     @Override
-    @Transactional(isolation = Isolation.SERIALIZABLE)
+    @Transactional
     public UrlCounterResponse increaseCounter(String url) {
         UrlCounter counter = urlCounterRepository.findByUrlAndDate(url, TODAY)
             .orElse(new UrlCounter(url, TODAY));
@@ -39,11 +37,33 @@ public class UrlCounterServiceImpl implements UrlCounterService {
         LOGGER.info("[increaseCounter before] url : {}, count : {}", counter.getUrl(),
             counter.getCount());
 
-        counter.increase(COUNT);
+        /*
+        if(counter.getId() != null){
+            counter.increase(1);
+        }
 
-        UrlCounter result = urlCounterRepository.save(counter);
+        UrlCounter result = urlCounterRepository.saveAndFlush(counter);
 
-        LOGGER.info("[increaseCounter after] url : {}, count : {}", result.getUrl(),
+        LOGGER.info("[increaseCounter insert] url : {}, count : {}", result.getUrl(),
+            result.getCount());
+
+        return new UrlCounterResponse(result);
+        */
+
+        if(counter.getId() == null){
+            UrlCounter result = urlCounterRepository.saveAndFlush(counter);
+
+            LOGGER.info("[increaseCounter insert] url : {}, count : {}", result.getUrl(),
+                result.getCount());
+
+            return new UrlCounterResponse(result);
+        }
+
+        urlCounterRepository.increaseUrlCount(counter.getId());
+
+        UrlCounter result = urlCounterRepository.findById(counter.getId()).get();
+
+        LOGGER.info("[increaseCounter update] url : {}, count : {}", result.getUrl(),
             result.getCount());
 
         return new UrlCounterResponse(result);

--- a/src/test/java/com/numble/tracking/service/UrlCounterServiceConcurrencyTest.java
+++ b/src/test/java/com/numble/tracking/service/UrlCounterServiceConcurrencyTest.java
@@ -3,6 +3,8 @@ package com.numble.tracking.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.numble.tracking.common.exception.CustomException;
+import com.numble.tracking.domain.UrlCounter;
+import com.numble.tracking.facade.OptimisticLockStockFacade;
 import com.numble.tracking.repository.UrlCounterRepository;
 import java.time.LocalDate;
 import java.util.concurrent.CountDownLatch;
@@ -10,6 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +26,14 @@ class UrlCounterServiceConcurrencyTest {
     private UrlCounterRepository urlCounterRepository;
 
     @Autowired
-    private UrlCounterService urlCounterService;
+    private OptimisticLockStockFacade urlCounterService;
+
+    //@BeforeEach
+    public void insert(){
+        UrlCounter urlCounter = new UrlCounter("https://jh7722.test.com/",LocalDate.now());
+
+        urlCounterRepository.saveAndFlush(urlCounter);
+    }
 
     @AfterEach
     public void delete() {
@@ -34,8 +44,8 @@ class UrlCounterServiceConcurrencyTest {
     @DisplayName("동시에 100명이 특정 URL을 조회")
     void increaseCounterConcurrency() throws InterruptedException {
         AtomicInteger successCount = new AtomicInteger();
-        int threadCount = 5;
-        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        int threadCount = 50;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
         for (int i = 0; i < threadCount; i++) {
@@ -59,7 +69,8 @@ class UrlCounterServiceConcurrencyTest {
         Long urlCounter = urlCounterRepository.findUrlCounter("https://jh7722.test.com/",
             LocalDate.now());
 
-        assertThat(urlCounter).isEqualTo(100);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(urlCounter).isEqualTo(50);
     }
 
 }


### PR DESCRIPTION
- 테이블 unique 설정 추가로 중복 방지
- Optimistic Lock을 이용해 insert 중복 시 재시도 로직 구현
- #6 에 대한 처리 PR

## Insert or update 가 동시에 이루어지는 Service를 가진 형태
### 기존방식 
- Jpa에서 제공하는 Save() 이용 insert/update 처리 (객체를 활용한 방식) 
- Pessimistic Lock 이용
- 다중 스레드 테스트에서 중복 Insert 이슈 발생 

### 변경방식 
- 일단 중복 Insert가 DB에 삽입되지 않도록 unique key 설정 추가 
- 기존의 save() 방식을 두가지 분리하여 진행 
   - 첫 데이터는 기존 방식과 동일하게 save() 이용
   - Id값이 있는 값을 update 할 경우 네이티브 쿼리로 update문 진행 (객체를 +1 하는 방식에서 쿼리에서 +1 진행하는 방식으로 변경)
- Optimistic Lock을 이용해 다중 insert를 시도한 에러들을 재시도하는 로직 구현 

### 이슈 해결

## 앞으로 진행할 사항 
### Redis를 이용한 동시성 처리 
### CI 작업하기 